### PR TITLE
Fixing signing and verifying

### DIFF
--- a/Issuer.ts
+++ b/Issuer.ts
@@ -26,12 +26,14 @@ export class Issuer extends Actor<Issuer> {
 	private constructor(issuer: string, readonly algorithm: Algorithm) {
 		super(issuer)
 	}
-	async sign(payload: Payload, issuedAt?: Date | number): Promise<Token> {
+	async sign(payload: Payload, issuedAt?: Date | number, standard?: boolean): Promise<Token> {
+	// async sign(payload: Payload, issuedAt?: Date | number): Promise<Token> {
 		payload = { ...this.payload, ...payload }
 		if (issuedAt)
 			payload.iat = typeof(issuedAt) == "number" ? issuedAt : issuedAt.getTime()
 		payload = await this.cryptos.reduce(async (p, c) => c.encrypt(await p), Promise.resolve(payload))
-		const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), "url") }`
+		const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), standard ? "standard" : "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), standard ? "standard" : "url") }`
+		// const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), "url") }`
 		return `${ data }.${ await this.algorithm.sign(data) }`
 	}
 	private static get issuedAt(): number {

--- a/Issuer.ts
+++ b/Issuer.ts
@@ -31,7 +31,7 @@ export class Issuer extends Actor<Issuer> {
 		if (issuedAt)
 			payload.iat = typeof(issuedAt) == "number" ? issuedAt : issuedAt.getTime()
 		payload = await this.cryptos.reduce(async (p, c) => c.encrypt(await p), Promise.resolve(payload))
-		const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header))) }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload))) }`
+		const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), "url") }`
 		return `${ data }.${ await this.algorithm.sign(data) }`
 	}
 	private static get issuedAt(): number {

--- a/Issuer.ts
+++ b/Issuer.ts
@@ -26,14 +26,12 @@ export class Issuer extends Actor<Issuer> {
 	private constructor(issuer: string, readonly algorithm: Algorithm) {
 		super(issuer)
 	}
-	async sign(payload: Payload, issuedAt?: Date | number, standard?: boolean): Promise<Token> {
-	// async sign(payload: Payload, issuedAt?: Date | number): Promise<Token> {
+	async sign(payload: Payload, issuedAt?: Date | number): Promise<Token> {
 		payload = { ...this.payload, ...payload }
 		if (issuedAt)
 			payload.iat = typeof(issuedAt) == "number" ? issuedAt : issuedAt.getTime()
 		payload = await this.cryptos.reduce(async (p, c) => c.encrypt(await p), Promise.resolve(payload))
-		const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), standard ? "standard" : "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), standard ? "standard" : "url") }`
-		// const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), "url") }`
+		const data = `${ Base64.encode(new TextEncoder().encode(JSON.stringify(this.header)), "url") }.${ Base64.encode(new TextEncoder().encode(JSON.stringify(payload)), "url") }`
 		return `${ data }.${ await this.algorithm.sign(data) }`
 	}
 	private static get issuedAt(): number {

--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -38,29 +38,4 @@ describe("Verifier", () => {
 		expect(verifier && await verifier.verify(base64url)).toBeTruthy()
 		expect(verifier && await verifier.verify(base64std)).toBeTruthy()
 	})
-	it("Verifying both standard base64 encoded and url base 64 encoded jwt with old and new issuers.", async () => {
-		const json = {
-			"url": "https://example.com?param1=123",
-			"url2": "https://example.com?param1=321",
-		}
-		const jwtUrl = validIssuer && await validIssuer.sign(json, 1570094329996)
-		const jwtStandard = validIssuer && await validIssuer.sign(json, 1570094329996, true)
-		const base64url = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20_cGFyYW0xPTMyMSJ9.D-QL6NX4Te8lNv2_aQlHRa8ETMuM4emKSGaMBo48r7s"
-		// Sign part in base64std is already url encoded since before. This test is for checking backwards compatibility with a previous incorrect use of base64 standard encoding when signing and verifying data (except for the last "sign" part of jwt).
-		const base64std = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20/cGFyYW0xPTMyMSJ9.v4jQ4w1rr5AYr0U_bAUv5Swn41NIuENvykhyt52NpX8"
-		expect(jwtUrl).toEqual(base64url)
-		expect(jwtStandard).toEqual(base64std)
-		expect(verifier && await verifier.verify(base64url)).toBeTruthy()
-		expect(verifier && await verifier.verify(base64std)).toBeTruthy()
-	})
-	it("Verifying both standard base64 encoded and url base 64 encoded jwt with old and new issuers (no '/').", async () => {
-		const json = {
-			"prop": "some value not including equal character",
-		}
-		const jwtUrl = validIssuer && await validIssuer.sign(json, 1570094329996)
-		const jwtStandard = validIssuer && await validIssuer.sign(json, 1570094329996, true)
-		expect(jwtUrl).toEqual(jwtStandard)
-		expect(verifier && await verifier.verify(jwtUrl)).toBeTruthy()
-		expect(verifier && await verifier.verify(jwtStandard)).toBeTruthy()
-	})
 })

--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -53,4 +53,14 @@ describe("Verifier", () => {
 		expect(verifier && await verifier.verify(base64url)).toBeTruthy()
 		expect(verifier && await verifier.verify(base64std)).toBeTruthy()
 	})
+	it("Verifying both standard base64 encoded and url base 64 encoded jwt with old and new issuers (no '/').", async () => {
+		const json = {
+			"prop": "some value not including equal character",
+		}
+		const jwtUrl = validIssuer && await validIssuer.sign(json, 1570094329996)
+		const jwtStandard = validIssuer && await validIssuer.sign(json, 1570094329996, true)
+		expect(jwtUrl).toEqual(jwtStandard)
+		expect(verifier && await verifier.verify(jwtUrl)).toBeTruthy()
+		expect(verifier && await verifier.verify(jwtStandard)).toBeTruthy()
+	})
 })

--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -11,7 +11,7 @@ describe("Verifier", () => {
 	it("not.a.token", async () => expect(await verifier.verify("not.a.token")).toEqual(undefined))
 	it("token without signature", async () => expect(await verifier.verify(noneIssuer && await noneIssuer.sign({ alpha: "a" }))).toEqual(undefined))
 	it("token with valid signature", async () => expect(await verifier.verify(validIssuer && await validIssuer.sign({ alpha: "a" }))).toEqual({"alpha": "a", "iat": 1570094329996, "iss": "audience"}))
-	it.skip("Verifying both standard base64 encoded and url base 64 encoded jwt.", async () => {
+	it("Verifying both standard base64 encoded and url base 64 encoded jwt.", async () => {
 		const json = {
 			"url": "https://example.com?param1=123",
 			"url2": "https://example.com?param1=321",
@@ -24,7 +24,7 @@ describe("Verifier", () => {
 		expect(noneVerifier && await noneVerifier.verify(base64url)).toBeTruthy()
 		expect(noneVerifier && await noneVerifier.verify(base64std)).toBeTruthy()
 	})
-	it.skip("Verifying both standard base64 encoded and url base 64 encoded jwt.", async () => {
+	it("Verifying both standard base64 encoded and url base 64 encoded jwt.", async () => {
 		const json = {
 			"url": "https://example.com?param1=123",
 			"url2": "https://example.com?param1=321",
@@ -37,6 +37,20 @@ describe("Verifier", () => {
 		expect(jwt).not.toEqual(base64std)
 		expect(verifier && await verifier.verify(base64url)).toBeTruthy()
 		expect(verifier && await verifier.verify(base64std)).toBeTruthy()
-		expect(false).toBeTruthy()
+	})
+	it("Verifying both standard base64 encoded and url base 64 encoded jwt with old and new issuers.", async () => {
+		const json = {
+			"url": "https://example.com?param1=123",
+			"url2": "https://example.com?param1=321",
+		}
+		const jwtUrl = validIssuer && await validIssuer.sign(json, 1570094329996)
+		const jwtStandard = validIssuer && await validIssuer.sign(json, 1570094329996, true)
+		const base64url = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20_cGFyYW0xPTMyMSJ9.D-QL6NX4Te8lNv2_aQlHRa8ETMuM4emKSGaMBo48r7s"
+		// Sign part in base64std is already url encoded since before. This test is for checking backwards compatibility with a previous incorrect use of base64 standard encoding when signing and verifying data (except for the last "sign" part of jwt).
+		const base64std = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20/cGFyYW0xPTMyMSJ9.v4jQ4w1rr5AYr0U_bAUv5Swn41NIuENvykhyt52NpX8"
+		expect(jwtUrl).toEqual(base64url)
+		expect(jwtStandard).toEqual(base64std)
+		expect(verifier && await verifier.verify(base64url)).toBeTruthy()
+		expect(verifier && await verifier.verify(base64std)).toBeTruthy()
 	})
 })

--- a/Verifier.spec.ts
+++ b/Verifier.spec.ts
@@ -2,12 +2,41 @@ import * as authly from "./index"
 
 describe("Verifier", () => {
 	const verifier = authly.Verifier.create("audience", authly.Algorithm.HS256("secret"))
-	const noneIssuer = authly.Issuer.create("audience", authly.Algorithm.none())
 	const validIssuer = authly.Issuer.create("audience", authly.Algorithm.HS256("secret"))
+	const noneVerifier = authly.Verifier.create("audience", authly.Algorithm.none())
+	const noneIssuer = authly.Issuer.create("audience", authly.Algorithm.none())
 	authly.Issuer.defaultIssuedAt = 1570094329996
 	it("undefined", async () => expect(await verifier.verify(undefined)).toEqual(undefined))
 	it("not a token", async () => expect(await verifier.verify("not a token")).toEqual(undefined))
 	it("not.a.token", async () => expect(await verifier.verify("not.a.token")).toEqual(undefined))
 	it("token without signature", async () => expect(await verifier.verify(noneIssuer && await noneIssuer.sign({ alpha: "a" }))).toEqual(undefined))
 	it("token with valid signature", async () => expect(await verifier.verify(validIssuer && await validIssuer.sign({ alpha: "a" }))).toEqual({"alpha": "a", "iat": 1570094329996, "iss": "audience"}))
+	it.skip("Verifying both standard base64 encoded and url base 64 encoded jwt.", async () => {
+		const json = {
+			"url": "https://example.com?param1=123",
+			"url2": "https://example.com?param1=321",
+		}
+		const jwt = noneIssuer && await noneIssuer.sign(json, 1570094329996)
+		const base64url = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20_cGFyYW0xPTMyMSJ9."
+		const base64std = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20/cGFyYW0xPTMyMSJ9."
+		expect(jwt).toEqual(base64url)
+		expect(jwt).not.toEqual(base64std)
+		expect(noneVerifier && await noneVerifier.verify(base64url)).toBeTruthy()
+		expect(noneVerifier && await noneVerifier.verify(base64std)).toBeTruthy()
+	})
+	it.skip("Verifying both standard base64 encoded and url base 64 encoded jwt.", async () => {
+		const json = {
+			"url": "https://example.com?param1=123",
+			"url2": "https://example.com?param1=321",
+		}
+		const jwt = validIssuer && await validIssuer.sign(json, 1570094329996)
+		const base64url = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20_cGFyYW0xPTMyMSJ9.D-QL6NX4Te8lNv2_aQlHRa8ETMuM4emKSGaMBo48r7s"
+		// Sign part in base64std is already url encoded since before. This test is for checking backwards compatibility with a previous incorrect use of base64 standard encoding when signing and verifying data (except for the last "sign" part of jwt).
+		const base64std = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhdWRpZW5jZSIsImlhdCI6MTU3MDA5NDMyOTk5NiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbT9wYXJhbTE9MTIzIiwidXJsMiI6Imh0dHBzOi8vZXhhbXBsZS5jb20/cGFyYW0xPTMyMSJ9.v4jQ4w1rr5AYr0U_bAUv5Swn41NIuENvykhyt52NpX8"
+		expect(jwt).toEqual(base64url)
+		expect(jwt).not.toEqual(base64std)
+		expect(verifier && await verifier.verify(base64url)).toBeTruthy()
+		expect(verifier && await verifier.verify(base64std)).toBeTruthy()
+		expect(false).toBeTruthy()
+	})
 })

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -20,14 +20,14 @@ export class Verifier extends Actor<Verifier> {
 	async verify(token: string | Token | undefined): Promise<Payload | undefined> {
 		let result: Payload | undefined
 		if (token) {
-			// token = token.replace("+", "-").replace("/", "_") // For backwards compatibility.
 			const splitted = token.split(".", 3)
 			if (splitted.length < 2)
 				result = undefined
 			else {
 				try {
-					const header: Header = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[0], "url")))
-					result = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[1], "url"))) as Payload
+					const oldDecoder = splitted[0].includes("/") || splitted[0].includes("+") || splitted[1].includes("/") || splitted[1].includes("+") // For backwards compatibility. splitted[2] correctly encoded.
+					const header: Header = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[0], oldDecoder ? "standard" : "url")))
+					result = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[1], oldDecoder ? "standard" : "url"))) as Payload
 					if (this.algorithms) {
 						const algorithm = this.algorithms[header.alg]
 						result = splitted.length == 3 && algorithm && await algorithm.verify(`${ splitted[0] }.${ splitted[1] }`, splitted[2]) ? result : undefined

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -20,13 +20,14 @@ export class Verifier extends Actor<Verifier> {
 	async verify(token: string | Token | undefined): Promise<Payload | undefined> {
 		let result: Payload | undefined
 		if (token) {
+			// token = token.replace("+", "-").replace("/", "_") // For backwards compatibility.
 			const splitted = token.split(".", 3)
 			if (splitted.length < 2)
 				result = undefined
 			else {
 				try {
-					const header: Header = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[0])))
-					result = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[1]))) as Payload
+					const header: Header = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[0], "url")))
+					result = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[1], "url"))) as Payload
 					if (this.algorithms) {
 						const algorithm = this.algorithms[header.alg]
 						result = splitted.length == 3 && algorithm && await algorithm.verify(`${ splitted[0] }.${ splitted[1] }`, splitted[2]) ? result : undefined

--- a/Verifier.ts
+++ b/Verifier.ts
@@ -25,7 +25,7 @@ export class Verifier extends Actor<Verifier> {
 				result = undefined
 			else {
 				try {
-					const oldDecoder = splitted[0].includes("/") || splitted[0].includes("+") || splitted[1].includes("/") || splitted[1].includes("+") // For backwards compatibility. splitted[2] correctly encoded.
+					const oldDecoder = token.includes("/") || token.includes("+") // For backwards compatibility.
 					const header: Header = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[0], oldDecoder ? "standard" : "url")))
 					result = JSON.parse(new TextDecoder().decode(Base64.decode(splitted[1], oldDecoder ? "standard" : "url"))) as Payload
 					if (this.algorithms) {


### PR DESCRIPTION
### Change
authly.Issuer.sign() will now correctly encode jwt as base64url encoded jwt instead of base64standard encoded jwt.
This makes them capable of being used in url:s.
authly.Verify() will be backwards compatible and is able to verify both base64url and base64standard encoded jwt.
### Why? 
Rarely used "=" in json data could sometimes introduce "/" or "+" in jwt, which created issues when trying to use callbacks url:s including jwt encoded json-objects with url properties containing "=".

```
json = {
  "url": "https://example.com?param1=123",
  "url2": "https://example.com?param1=321",
}

jwt (url, not signed) = "eyJhb ... b20_cGFyYW0xPTMyMSJ9."
jwt (standard, not signed) = "eyJhb ... b20/cGFyYW0xPTMyMSJ9."
```

### Use caution when updating 
It has been thoroughly tested but projects using authly (specifically Issuer.sign() and Verifier.verify()) should make sure to update repositories using authly.Verifier.verify() first or at the same time as repositories using authly.Issuer.sign().